### PR TITLE
Fix 6.2.9 Find Index of a String (MatchingString)

### DIFF
--- a/Unit 6 - Array/6.2.9 Find Index of a String (MatchingString).java
+++ b/Unit 6 - Array/6.2.9 Find Index of a String (MatchingString).java
@@ -8,7 +8,7 @@ public class MatchingString
         // your code goes here!
         for (int i = 0; i < arr.length; i++)
         {
-            if (arr[i] == myString)
+            if (arr[i].equals(myString))
             {
                 return i;
             }


### PR DESCRIPTION
6.2.9 fails the first test case because the string references don't match, we have to use .equals() instead of == to compare the contents of the strings.